### PR TITLE
A bunch of fixes

### DIFF
--- a/tl-expected-tests/build/bootstrap.build
+++ b/tl-expected-tests/build/bootstrap.build
@@ -5,3 +5,4 @@ using config
 using test
 using install
 using dist
+using test

--- a/tl-expected-tests/build/root.build
+++ b/tl-expected-tests/build/root.build
@@ -18,3 +18,6 @@ hxx{*}: cxx.importable = true
 # The test target for cross-testing (running tests under Wine, etc).
 #
 test.target = $cxx.target
+
+# In this package, all executables are tests.
+exe{*} : test = true

--- a/tl-expected-tests/manifest
+++ b/tl-expected-tests/manifest
@@ -10,5 +10,3 @@ email: wmbat-dev@protonmail.com
 #build-error-email: wmbat-dev@protonmail.com
 depends: * build2 >= 0.14.0
 depends: * bpkg >= 0.14.0
-
-depends: tl-expected == 1.0.0

--- a/tl-expected/basic-test/.gitignore
+++ b/tl-expected/basic-test/.gitignore
@@ -1,0 +1,5 @@
+basic-test
+
+# Testscript output directory (can be symlink).
+#
+test-basic-test

--- a/tl-expected/basic-test/basic-test.cpp
+++ b/tl-expected/basic-test/basic-test.cpp
@@ -1,0 +1,16 @@
+#include <iostream>
+
+#include <tl/expected.hpp>
+
+int main (int argc, char* argv[])
+{
+  using namespace std;
+
+  if (argc < 2)
+  {
+    cerr << "error: missing name" << endl;
+    return 1;
+  }
+
+  cout << "Hello, " << argv[1] << '!' << endl;
+}

--- a/tl-expected/basic-test/buildfile
+++ b/tl-expected/basic-test/buildfile
@@ -1,0 +1,8 @@
+libs =
+import libs += tl-expected%lib{tl-expected}
+
+exe{basic-test}: {hxx ixx txx cxx}{**} $libs testscript
+
+cxx.poptions =+ "-I$out_root" "-I$src_root"
+
+exe{*}: test = true

--- a/tl-expected/basic-test/testscript
+++ b/tl-expected/basic-test/testscript
@@ -1,0 +1,9 @@
+: basics
+:
+$* 'World' >'Hello, World!'
+
+: missing-name
+:
+$* 2>>EOE != 0
+error: missing name
+EOE

--- a/tl-expected/build/bootstrap.build
+++ b/tl-expected/build/bootstrap.build
@@ -4,3 +4,4 @@ using version
 using config
 using install
 using dist
+using test

--- a/tl-expected/build/export.build
+++ b/tl-expected/build/export.build
@@ -1,6 +1,6 @@
 $out_root/
 {
-  include tl-expected/
+  include tl/
 }
 
-export $out_root/tl-expected/$import.target
+export $out_root/tl/$import.target

--- a/tl-expected/manifest
+++ b/tl-expected/manifest
@@ -10,5 +10,8 @@ url: https://example.org/tl
 email: wmbat-dev@protonmail.com
 #build-error-email: wmbat-dev@protonmail.com
 
+tests: tl-expected-tests == $
+
 depends: * build2 >= 0.14.0
 depends: * bpkg >= 0.14.0
+


### PR DESCRIPTION
I fixed the following issues:

- wrong paths in export file;
- test exes not being marked as tests;
- dependency between test package and library package not using the `test` field in `manifest` (see https://github.com/build2/HOWTO/blob/master/entries/handle-tests-with-extra-dependencies.md)
- workaround https://github.com/build2/build2/issues/192 by adding a very basic test in the library package

Currently the test package tests don't succeed but that's because I didn't fix the code inside, as it should be the code from the tests.